### PR TITLE
AK-339 [Feat] 팔로워, 팔로잉 리스트 조회 시 요청자에 대한 팔로우 상태 추가

### DIFF
--- a/src/main/java/com/alphaka/userservice/controller/FollowApi.java
+++ b/src/main/java/com/alphaka/userservice/controller/FollowApi.java
@@ -4,7 +4,7 @@ import static com.alphaka.userservice.exception.ErrorCode.*;
 
 import com.alphaka.userservice.dto.response.ApiResponse;
 import com.alphaka.userservice.dto.response.UserInfoResponse;
-import com.alphaka.userservice.exception.ErrorCode;
+import com.alphaka.userservice.dto.response.UserInfoWithFollowStatusResponse;
 import com.alphaka.userservice.swagger.annotation.ApiErrorResponseExamples;
 import com.alphaka.userservice.swagger.annotation.ApiSuccessResponseExample;
 import com.alphaka.userservice.util.AuthenticatedUserInfo;
@@ -13,6 +13,7 @@ import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.enums.ParameterIn;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.servlet.http.HttpServletRequest;
 import java.util.List;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -71,11 +72,11 @@ public interface FollowApi {
 
     @Operation(
             summary = "사용자 팔로잉 목록 조회 요청",
-            description = "해당 id를 가진 사용자의 팔로잉 목록을 조회하는 API 입니다.",
+            description = "해당 id를 가진 사용자의 팔로잉 목록을 조회하는 API 입니다. accessToken을 담아 인증 필터를 거치게 할 경우 자신과의 팔로우 여부를 나타내는 followStatus가 함께 반환합니다. 인증 필터를 거치지 않는다면 기본적으로 followStatus값이  false가 반환됩니다.",
             tags = {"External API"},
             parameters = {
                     @Parameter(
-                            name = "userId",
+                            name = "targetUserId",
                             description = "사용자의 고유한 ID",
                             required = true,
                             example = "1",
@@ -84,21 +85,22 @@ public interface FollowApi {
                     )
             }
     )
-    @ApiSuccessResponseExample(responseClass = List.class, data = true, status = HttpStatus.OK, genericType = UserInfoResponse.class)
+    @ApiSuccessResponseExample(responseClass = List.class, data = true, status = HttpStatus.OK, genericType = UserInfoWithFollowStatusResponse.class)
     @ApiErrorResponseExamples(
             value = {USER_NOT_FOUND},
             name = {"사용자 없음"},
             description = {"존재하지 않는 사용자입니다."}
     )
-    ApiResponse<List<UserInfoResponse>> following(@PathVariable("userId") Long userId);
+    ApiResponse<List<UserInfoWithFollowStatusResponse>> following(
+            @PathVariable("targetUserId") Long targetUserId, HttpServletRequest request);
 
     @Operation(
             summary = "사용자 팔로워 목록 조회 요청",
-            description = "해당 id를 가진 사용자의 팔로워 목록을 조회하는 API 입니다.",
+            description = "해당 id를 가진 사용자의 팔로워 목록을 조회하는 API 입니다. accessToken을 담아 인증 필터를 거치게 할 경우 자신과의 팔로우 여부도 함께 반환합니다.  인증 필터를 거치지 않는다면 기본적으로 followStatus값이  false가 반환됩니다.",
             tags = {"External API"},
             parameters = {
                     @Parameter(
-                            name = "userId",
+                            name = "targetUserId",
                             description = "사용자의 고유한 ID",
                             required = true,
                             example = "1",
@@ -107,13 +109,14 @@ public interface FollowApi {
                     )
             }
     )
-    @ApiSuccessResponseExample(responseClass = List.class, data = true, status = HttpStatus.OK, genericType = UserInfoResponse.class)
+    @ApiSuccessResponseExample(responseClass = List.class, data = true, status = HttpStatus.OK, genericType = UserInfoWithFollowStatusResponse.class)
     @ApiErrorResponseExamples(
             value = {USER_NOT_FOUND},
             name = {"사용자 없음"},
             description = {"존재하지 않는 사용자입니다."}
     )
-    ApiResponse<List<UserInfoResponse>> follower(@PathVariable("userId") Long userId);
+    ApiResponse<List<UserInfoWithFollowStatusResponse>> follower(
+            @PathVariable("targetUserId") Long targetUserId, HttpServletRequest request);
 
     @Operation(
             summary = "사용자 팔로우 여부 조회 요청",

--- a/src/main/java/com/alphaka/userservice/controller/FollowController.java
+++ b/src/main/java/com/alphaka/userservice/controller/FollowController.java
@@ -2,8 +2,10 @@ package com.alphaka.userservice.controller;
 
 import com.alphaka.userservice.dto.response.ApiResponse;
 import com.alphaka.userservice.dto.response.UserInfoResponse;
+import com.alphaka.userservice.dto.response.UserInfoWithFollowStatusResponse;
 import com.alphaka.userservice.service.FollowService;
 import com.alphaka.userservice.util.AuthenticatedUserInfo;
+import jakarta.servlet.http.HttpServletRequest;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -54,7 +56,7 @@ public class FollowController implements FollowApi {
     @ResponseBody
     public ApiResponse<Boolean> followStatus(@RequestParam("userId") Long userId,
                                              AuthenticatedUserInfo authenticatedUserInfo) {
-        log.info("유저 {}의 유저 {} 팔로우 여부 조회 요청", authenticatedUserInfo.getId(),userId);
+        log.info("유저 {}의 유저 {} 팔로우 여부 조회 요청", authenticatedUserInfo.getId(), userId);
         boolean isFollowing = followService.isFollowing(authenticatedUserInfo.getId(), userId);
 
         log.info("팔로잉 여부:{}", isFollowing);
@@ -63,25 +65,29 @@ public class FollowController implements FollowApi {
 
     //사용자의 팔로잉 목록
     @Override
-    @GetMapping("/{userId}/following")
+    @GetMapping("/{targetUserId}/following")
     @ResponseBody
-    public ApiResponse<List<UserInfoResponse>> following(@PathVariable("userId") Long userId) {
-        log.info("유저 {}의 팔로잉 목록 조회 요청", userId);
-        List<UserInfoResponse> followings = followService.followings(userId);
+    public ApiResponse<List<UserInfoWithFollowStatusResponse>> following(
+            @PathVariable("targetUserId") Long targetUserId, HttpServletRequest request) {
+        log.info("유저 {}의 팔로잉 목록 조회 요청", targetUserId);
+        List<UserInfoWithFollowStatusResponse> followings = followService.followingsWithStatus(targetUserId, request);
 
-        log.info("유저 {}의 팔로잉 목록 조회 요청 성공", userId);
+        log.info("유저 {}의 팔로잉 목록 조회 요청 성공", targetUserId);
         return ApiResponse.createSuccessResponseWithData(HttpStatus.OK.value(), followings);
     }
 
     //사용자의 팔로워 목록
     @Override
-    @GetMapping("/{userId}/follower")
+    @GetMapping("/{targetUserId}/follower")
     @ResponseBody
-    public ApiResponse<List<UserInfoResponse>> follower(@PathVariable("userId") Long userId) {
-        log.info("유저 {}의 팔로워 목록 조회 요청", userId);
-        List<UserInfoResponse> followers = followService.followers(userId);
+    public ApiResponse<List<UserInfoWithFollowStatusResponse>> follower(
+            @PathVariable("targetUserId") Long targetUserId,
+            HttpServletRequest request) {
+        log.info("유저 {}의 팔로워 목록 조회 요청", targetUserId);
+        List<UserInfoWithFollowStatusResponse> followers = followService.followersWithStatus(
+                targetUserId, request);
 
-        log.info("유저 {}의 팔로워 목록 조회 요청 성공", userId);
+        log.info("유저 {}의 팔로워 목록 조회 요청 성공", targetUserId);
         return ApiResponse.createSuccessResponseWithData(HttpStatus.OK.value(), followers);
     }
 

--- a/src/main/java/com/alphaka/userservice/dto/response/UserInfoWithFollowStatusResponse.java
+++ b/src/main/java/com/alphaka/userservice/dto/response/UserInfoWithFollowStatusResponse.java
@@ -1,0 +1,24 @@
+package com.alphaka.userservice.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+public class UserInfoWithFollowStatusResponse {
+
+    @Schema(example = "1")
+    private Long userId;
+    @Schema(example = "ImUser1")
+    private String nickname;
+    @Schema(example = "/img/default")
+    private String profileImage;
+    @Schema(example = "true")
+    private Boolean followStatus = false;
+
+}

--- a/src/main/java/com/alphaka/userservice/entity/Follow.java
+++ b/src/main/java/com/alphaka/userservice/entity/Follow.java
@@ -1,6 +1,9 @@
 package com.alphaka.userservice.entity;
 
+import com.alphaka.userservice.dto.response.UserInfoWithFollowStatusResponse;
 import jakarta.persistence.Column;
+import jakarta.persistence.ColumnResult;
+import jakarta.persistence.ConstructorResult;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EntityListeners;
 import jakarta.persistence.GeneratedValue;
@@ -8,6 +11,8 @@ import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
+import jakarta.persistence.NamedNativeQuery;
+import jakarta.persistence.SqlResultSetMapping;
 import jakarta.persistence.Table;
 import jakarta.persistence.UniqueConstraint;
 import java.time.LocalDateTime;
@@ -16,6 +21,8 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.hibernate.annotations.NotFound;
+import org.hibernate.annotations.NotFoundAction;
 import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
@@ -28,6 +35,62 @@ import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 @Table(uniqueConstraints = {
         @UniqueConstraint(columnNames = {"follower_id", "followed_id"})
 })
+@NamedNativeQuery(
+        name = "find_followings_with_follow_status",
+        query = """
+                SELECT
+                        u.user_id AS userId,
+                        u.nickname AS nickname,
+                        u.profile_image AS profileImage,
+                        CASE
+                            WHEN f1.followed_id IS NOT NULL THEN TRUE
+                            ELSE FALSE
+                            END AS followStatus
+                FROM follow f
+                INNER JOIN
+                    users u ON u.user_id = f.followed_id
+                        AND u.deleted_at IS NULL
+                LEFT JOIN
+                    follow f1 ON f1.followed_id = u.user_id
+                        AND f1.follower_id = :requestUserId
+                WHERE
+                    f.follower_id = :targetUserId
+                """,
+        resultSetMapping = "UserInfoWithFollowStatusMapping")
+@NamedNativeQuery(
+        name = "find_followers_with_follow_status",
+        query = """
+                SELECT
+                        u.user_id AS userId,
+                        u.nickname AS nickname,
+                        u.profile_image AS profileImage,
+                        CASE
+                            WHEN f1.followed_id IS NOT NULL THEN TRUE
+                            ELSE FALSE
+                            END AS followStatus
+                FROM follow f
+                INNER JOIN
+                    users u ON u.user_id = f.follower_id
+                        AND u.deleted_at IS NULL
+                LEFT JOIN
+                    follow f1 ON f1.followed_id = u.user_id
+                        AND f1.follower_id = :requestUserId
+                WHERE
+                    f.followed_id = :targetUserId
+                """,
+        resultSetMapping = "UserInfoWithFollowStatusMapping")
+@SqlResultSetMapping(
+        name = "UserInfoWithFollowStatusMapping",
+        classes = @ConstructorResult(
+                targetClass = UserInfoWithFollowStatusResponse.class,
+                columns = {
+                        @ColumnResult(name = "userId", type = Long.class),
+                        @ColumnResult(name = "nickname", type = String.class),
+                        @ColumnResult(name = "profileImage", type = String.class),
+                        @ColumnResult(name = "followStatus", type = Boolean.class)
+                }
+        )
+)
 public class Follow {
 
     @Id
@@ -38,11 +101,13 @@ public class Follow {
     // 팔로우하는 유저
     @ManyToOne
     @JoinColumn(name = "follower_id", nullable = false)
+    @NotFound(action = NotFoundAction.IGNORE) // FetchNotFound 무시
     private User follower;
 
     // 팔로우된 유저
     @ManyToOne
     @JoinColumn(name = "followed_id", nullable = false)
+    @NotFound(action = NotFoundAction.IGNORE)
     private User followed;
 
     @CreatedDate

--- a/src/main/java/com/alphaka/userservice/repository/FollowRepository.java
+++ b/src/main/java/com/alphaka/userservice/repository/FollowRepository.java
@@ -1,8 +1,7 @@
 package com.alphaka.userservice.repository;
 
-import com.alphaka.userservice.dto.response.UserInfoResponse;
+import com.alphaka.userservice.dto.response.UserInfoWithFollowStatusResponse;
 import com.alphaka.userservice.entity.Follow;
-import com.alphaka.userservice.entity.User;
 import java.util.List;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -11,18 +10,29 @@ import org.springframework.data.repository.query.Param;
 
 public interface FollowRepository extends JpaRepository<Follow, Long> {
 
-    Optional<Follow> findByFollowerAndFollowed(User follower, User followed);
+    @Query(value = "SELECT * FROM follow f WHERE f.follower_id = :followerId AND f.followed_id = :followedId", nativeQuery = true)
+    Optional<Follow> findByFollowerAndFollowed(@Param("followerId") Long followerId,
+                                               @Param("followedId") Long followedId);
 
 
     // 해당 사용자가 팔로우하는 유저들
-    @Query("select new com.alphaka.userservice.dto.response.UserInfoResponse(u.id, u.nickname, u.profileImage) "
+    @Query("select new com.alphaka.userservice.dto.response.UserInfoWithFollowStatusResponse(u.id, u.nickname, u.profileImage, false) "
             + "from Follow f join f.followed u where f.follower.id = :userId")
-    List<UserInfoResponse> findFollowingsByUserId(@Param("userId") Long userId);
+    List<UserInfoWithFollowStatusResponse> findFollowingsByUserId(@Param("userId") Long userId);
 
 
     // 해당 사용자를 팔로우하는 유저들
-    @Query("select new com.alphaka.userservice.dto.response.UserInfoResponse(u.id, u.nickname, u.profileImage) "
+    @Query("select new com.alphaka.userservice.dto.response.UserInfoWithFollowStatusResponse(u.id, u.nickname, u.profileImage, false) "
             + "from Follow f join f.follower u where f.followed.id = :userId")
-    List<UserInfoResponse> findFollowersByUserId(@Param("userId") Long userId);
+    List<UserInfoWithFollowStatusResponse> findFollowersByUserId(@Param("userId") Long userId);
+
+    @Query(name = "find_followings_with_follow_status", nativeQuery = true)
+    List<UserInfoWithFollowStatusResponse> findFollowingsWithFollowStatusByRequestUserIdAndTargetUserId(
+            @Param("requestUserId") Long requestUserId, @Param("targetUserId") Long targetUserId);
+
+    @Query(name = "find_followers_with_follow_status", nativeQuery = true)
+    List<UserInfoWithFollowStatusResponse> findFollowersWithFollowStatusByRequestUserIdAndTargetUserId(
+            @Param("requestUserId") Long requestUserId, @Param("targetUserId") Long targetUserId);
+
 
 }


### PR DESCRIPTION
## 📌 Summary
해당 PR에서 구현하거나 수정한 내용의 요약을 작성해주세요.

- 팔로워, 팔로잉 리스트 조회 시 요청자에 대한 팔로우 상태 추가

## 📝 Changes
변경된 주요 사항을 항목별로 정리해주세요.

- 팔로잉, 팔로워 리스트 응답에 followStatus 추가
- 로그인한 사용자의 경우 팔로잉, 팔로워 리스트에 보이는 유저들에 대해 팔로우 여부를 조회하여 응답
- 로그인하지 않은 사용자는 기본적으로 팔로우 여부가 모두 false값으로 응답
- SqlRestriction으로 인한 fetchNotFoundException 처리
- Jpa가 생성하는 비효율적인 쿼리들은 네이티브 쿼리로 작성

## ✅ Checklist
PR을 제출하기 전에 확인해야 할 사항들을 체크하세요. (✓)

- [x] 코드가 정상적으로 컴파일되고 작동하는지 확인했습니다.
- [x] 기존 기능에 영향이 없는지 확인했습니다.
- [x] 문서 업데이트가 필요한 경우 업데이트했습니다.

## 🔗 Related Issue
연관된 이슈 번호를 기재해주세요. (e.g., AK-201)

- AK-339

## 📸 Screenshots (Optional)
필요에 따라 스크린샷을 첨부하여 설명해주세요.

- 